### PR TITLE
Fix message retrieval & subscription

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -344,8 +344,9 @@ class ZulipClient {
 
   async subscribeToStream(streamName: string) {
     try {
-      const subscriptions = [{ name: streamName }];
-      return await this.client.streams.subscribe({ subscriptions: JSON.stringify(subscriptions) });
+      return await this.client.callEndpoint("users/me/subscriptions", "POST", {
+        subscriptions: [{ name: streamName }],
+      });
     } catch (error) {
       console.error("Error subscribing to stream:", error);
       throw error;

--- a/index.ts
+++ b/index.ts
@@ -320,9 +320,9 @@ class ZulipClient {
       ];
       
       const params = {
-        narrow: JSON.stringify(narrow),
-        num_before: Math.floor(limit / 2),
-        num_after: Math.floor(limit / 2),
+        narrow: narrow,
+        num_before: limit,
+        num_after: 0,
         anchor: anchor,
       };
       


### PR DESCRIPTION
## Fix three bugs in `getMessages` and `subscribeToStream`

### 1. `zulip_get_channel_history` always fails with `narrow is not a list`

`getMessages` pre-serialised the narrow, but `zulip-js` serialises it again
(`resources/messages.js`: `if (params.narrow) params.narrow = JSON.stringify(params.narrow)`).
The server received a quoted JSON string instead of a list and rejected every request.

Fixed by passing the array and letting the library own serialisation.

### 2. `limit` returned half the requested messages

```js
num_before: Math.floor(limit / 2),
num_after:  Math.floor(limit / 2),   // anchor is "newest" - nothing exists after it

num_after could never match, so limit: 20 returned 10. Now num_before: limit, num_after: 0.
```

### 3. zulip_subscribe_to_channel threw TypeError on every call

`client.streams.subscribe` does not exist in zulip-js; the streams surface is
retrieve, getStreamId, subscriptions, topics, deleteById, and subscriptions is read-only.
The call threw before issuing any request.

Replaced with a direct `callEndpoint("users/me/subscriptions", "POST", ...)`. The array is passed raw
because the transport JSON-encodes arrays on POST only (api.js) - pre-stringifying would reintroduce bug #1.

⚠️ Heads up for maintainers: `POST /users/me/subscriptions` creates channels that don't exist,
if the account has permission. Now that this tool actually reaches the endpoint, a typo'd or
hallucinated channel_name can create a channel rather than error. I did not test this so I'm reporting the mechanism, not a confirmed result.
Worth considering an existence check before subscribing, or documenting that this tool should be
gated behind user approval.

### Verification

Each fix was driven through the built server over stdio:

1. history returns messages instead of BAD_REQUEST.
2. limit: 30 returns 30 (was 15); default returns 20 (was 10).
3. subscribe succeeds and the subscription list grows; re-subscribing to an existing
channel returns already_subscribed and changes nothing. Test state was restored afterwards.